### PR TITLE
Add DTOs for creating stages in the application

### DIFF
--- a/Project/ConsoleProject/DTOs/RequestModels/Stage/CreateStage.cs
+++ b/Project/ConsoleProject/DTOs/RequestModels/Stage/CreateStage.cs
@@ -1,14 +1,25 @@
-using ConsoleProject.Enums;
-using ConsoleProject.Models;
+using ConsoleProject.Enums; 
+using ConsoleProject.Models; 
 
-namespace ConsoleProject.DTOs.RequestModels;
-public class CreateVideoInterviewStage
+namespace ConsoleProject.DTOs.RequestModels
 {
-    public List<VideoInterviewQuestion> VideoInterviewQuestions {get; set;} = new List<VideoInterviewQuestion>();
-}
-public class CreateStage
-{
-    public StageType StageType {get; set;}
-    public string StageName{get; set;}
-    public CreateVideoInterviewStage CreateVideoInterviewStage {get; set;}
+    // CreateVideoInterviewStage class represents the data transfer object (DTO) used for creating a video interview stage
+    public class CreateVideoInterviewStage
+    {
+        // VideoInterviewQuestions property represents a list of video interview questions for the stage
+        public List<VideoInterviewQuestion> VideoInterviewQuestions { get; set; } = new List<VideoInterviewQuestion>();
+    }
+
+    // CreateStage class represents the data transfer object (DTO) used for creating a general stage
+    public class CreateStage
+    {
+        // StageType property represents the type of the stage (e.g., video interview, assessment, etc.)
+        public StageType StageType { get; set; }
+
+        // StageName property represents the name of the stage
+        public string StageName { get; set; }
+
+        // CreateVideoInterviewStage property represents the video interview stage details, if applicable
+        public CreateVideoInterviewStage CreateVideoInterviewStage { get; set; }
+    }
 }


### PR DESCRIPTION
CreateVideoInterviewStage and CreateStage - to facilitate the creation of different stages within the ConsoleProject application.

The CreateVideoInterviewStage DTO is designed for stages that involve video interviews and includes a property to store a list of VideoInterviewQuestion objects. This allows the application to collect all the video interview questions associated with the stage in a structured manner.

On the other hand, the CreateStage DTO is a more generic representation for creating various stages. It includes properties for StageType, which denotes the type of the stage (e.g., video interview, assessment), and StageName, which represents the name of the stage. Additionally, it has a CreateVideoInterviewStage property that can hold the details specific to video interview stages when applicable.

By implementing these DTOs, the application can efficiently capture and organize stage-related information during the stage creation process, ensuring a more streamlined and structured approach to managing the different stages in the ConsoleProject.