### PR TITLE
Add DTOs for updating different stage types

### DIFF
--- a/Project/ConsoleProject/DTOs/RequestModels/Stage/UpdateStage.cs
+++ b/Project/ConsoleProject/DTOs/RequestModels/Stage/UpdateStage.cs
@@ -1,13 +1,21 @@
-using ConsoleProject.Models;
+using ConsoleProject.Models; 
 
-namespace ConsoleProject.DTOs.RequestModels.Stage;
-
+namespace ConsoleProject.DTOs.RequestModels.Stage
+{
+    // UpdateVideoInterviewStage class represents the data transfer object (DTO) used for updating a video interview stage
     public class UpdateVideoInterviewStage
     {
-        public string StageName {get; set;}
-        public List<VideoInterviewQuestion> VideoInterviewQuestions {get; set;} = new List<VideoInterviewQuestion>();
+        // StageName property represents the updated name of the video interview stage
+        public string StageName { get; set; }
+
+        // VideoInterviewQuestions property represents a list of updated video interview questions for the stage
+        public List<VideoInterviewQuestion> VideoInterviewQuestions { get; set; } = new List<VideoInterviewQuestion>();
     }
+
+    // UpdateUsualStage class represents the data transfer object (DTO) used for updating a usual (generic) stage
     public class UpdateUsualStage
     {
-        public string StageName {get; set;}
+        // StageName property represents the updated name of the usual stage
+        public string StageName { get; set; }
     }
+}


### PR DESCRIPTION
 UpdateVideoInterviewStage and UpdateUsualStage - to facilitate the updating of different stage types within the ConsoleProject application.

The UpdateVideoInterviewStage DTO is designed for updating video interview stages and includes a StageName property to store the updated name of the video interview stage. Additionally, it has a VideoInterviewQuestions property, which represents the updated list of video interview questions for the stage. By providing this property, the application can efficiently manage and process any changes made to the video interview questions associated with the stage.

On the other hand, the UpdateUsualStage DTO is a more generic representation for updating usual (generic) stages. It includes a StageName property to store the updated name of the usual stage. Since usual stages do not have specific video interview questions or other unique properties, this DTO serves as a simple and effective way to handle updates for such stages.

By implementing these DTOs, the application gains the capability to update stage-related information, allowing users to modify stage names and video interview questions as needed in the ConsoleProject application.