### PR TITLE
Add ProgramModel DTO

### DIFF
--- a/Project/ConsoleProject/DTOs/RetrievalModels/Program/ProgramModel.cs
+++ b/Project/ConsoleProject/DTOs/RetrievalModels/Program/ProgramModel.cs
@@ -1,21 +1,49 @@
-using ConsoleProject.Enums;
+using ConsoleProject.Enums; 
 using ConsoleProject.Models;
+using System; 
 
-namespace ConsoleProject.DTOs.RetrievalModels;
-
-public class ProgramModel
+namespace ConsoleProject.DTOs.RetrievalModels
 {
-    public DateTime ProgramStart { get; set; }
-    public DateTime ApplicationStart { get; set; }
-    public DateTime ApplicationEnds { get; set; }
-    public MinQualification ApplicantQualification { get; set; }
-    public List<ProgramLocation> ProgramLocations { get; set; } = new List<ProgramLocation>();
-    public int DurationInMonths { get; set; }
-    public int MaxApplications { get; set; }
-    public string ProgramTitle { get; set; }
-    public string Description { get; set; }
-    public List<Skills> ApplicantSkills { get; set; } = new List<Skills>();
-    public List<string> Benefits { get; set; } = new List<string>();
-    public List<string> ApplicationCriteria { get; set; } = new List<string>();
-    public ProgramType ProgramType { get; set; }
+    // ProgramModel represents the data transfer object (DTO) for a program retrieval model.
+    public class ProgramModel
+    {
+        // ProgramStart property holds the start date of the program.
+        public DateTime ProgramStart { get; set; }
+
+        // ApplicationStart property holds the start date of the application process.
+        public DateTime ApplicationStart { get; set; }
+
+        // ApplicationEnds property holds the end date of the application process.
+        public DateTime ApplicationEnds { get; set; }
+
+        // ApplicantQualification property holds the minimum qualification required for applicants. It uses the MinQualification enumeration.
+        public MinQualification ApplicantQualification { get; set; }
+
+        // ProgramLocations property holds the list of program locations. It uses the ProgramLocation class from the Models namespace.
+        public List<ProgramLocation> ProgramLocations { get; set; } = new List<ProgramLocation>();
+
+        // DurationInMonths property holds the duration of the program in months.
+        public int DurationInMonths { get; set; }
+
+        // MaxApplications property holds the maximum number of applications allowed for the program.
+        public int MaxApplications { get; set; }
+
+        // ProgramTitle property holds the title of the program.
+        public string ProgramTitle { get; set; }
+
+        // Description property holds the description of the program.
+        public string Description { get; set; }
+
+        // ApplicantSkills property holds the list of applicant skills. It uses the Skills enumeration.
+        public List<Skills> ApplicantSkills { get; set; } = new List<Skills>();
+
+        // Benefits property holds the list of program benefits.
+        public List<string> Benefits { get; set; } = new List<string>();
+
+        // ApplicationCriteria property holds the list of application criteria.
+        public List<string> ApplicationCriteria { get; set; } = new List<string>();
+
+        // ProgramType property represents the type of the program. It uses the ProgramType enumeration.
+        public ProgramType ProgramType { get; set; }
+    }
 }


### PR DESCRIPTION
ProgramModel data transfer object (DTO) to the ConsoleProject application. The ProgramModel class represents a retrieval model for a program and includes properties such as ProgramStart, ApplicationStart, ApplicationEnds, ApplicantQualification, ProgramLocations, DurationInMonths, MaxApplications, ProgramTitle, Description, ApplicantSkills, Benefits, ApplicationCriteria, and ProgramType. The ApplicantQualification property uses the MinQualification enumeration, and the ProgramLocations property holds a list of ProgramLocation objects from the Models .

The ApplicantSkills property uses the Skills enumeration, and the ProgramType property utilizes the ProgramType enumeration.