### PR TITLE
Add VideoInterviewStage and VideoInterviewQuestion models

### DIFF
--- a/Project/ConsoleProject/Models/Stages/VideoInterviewStage.cs
+++ b/Project/ConsoleProject/Models/Stages/VideoInterviewStage.cs
@@ -1,14 +1,25 @@
-namespace ConsoleProject.Models;
-
-public class VideoInterviewStage
+namespace ConsoleProject.Models
 {
-    public List<VideoInterviewQuestion> VideoInterviewQuestions {get; set;}
-}
+    // VideoInterviewStage represents a class that holds a list of video interview questions for a stage.
+    public class VideoInterviewStage
+    {
+        // VideoInterviewQuestions represents a list of video interview questions for the stage.
+        public List<VideoInterviewQuestion> VideoInterviewQuestions { get; set; }
+    }
 
-public class VideoInterviewQuestion
-{
-    public string VideoTextQuestion {get; set;}
-    public string AdditionalSubmissionInformation{get; set;}
-    public string MaxDurationOfVideo {get; set;}
-    public int DeadlineInNumberOfDays {get; set;}
+    // VideoInterviewQuestion represents a class that holds information about a video interview question.
+    public class VideoInterviewQuestion
+    {
+        // VideoTextQuestion stores the text of the video interview question.
+        public string VideoTextQuestion { get; set; }
+
+        // AdditionalSubmissionInformation provides additional information for the video interview question submission.
+        public string AdditionalSubmissionInformation { get; set; }
+
+        // MaxDurationOfVideo represents the maximum allowed duration of the video response.
+        public string MaxDurationOfVideo { get; set; }
+
+        // DeadlineInNumberOfDays indicates the number of days allowed to respond to the question.
+        public int DeadlineInNumberOfDays { get; set; }
+    }
 }


### PR DESCRIPTION
Add VideoInterviewStage and VideoInterviewQuestion, to the application. The VideoInterviewStage class holds a list of VideoInterviewQuestion objects, representing a stage with multiple video interview questions. On the other hand, the VideoInterviewQuestion class holds information about a single video interview question, including the text of the question, additional submission information, maximum video duration, and the deadline to submit the response in the number of days. These models will be used to manage video interview-related data within the application.