### PR TITLE
Add Stage model

### DIFF
--- a/Project/ConsoleProject/Models/Stages/Stage.cs
+++ b/Project/ConsoleProject/Models/Stages/Stage.cs
@@ -1,14 +1,24 @@
 using System.ComponentModel.DataAnnotations;
 using ConsoleProject.Enums;
 
-namespace ConsoleProject.Models;
-
-public class Stage : BaseModel
+namespace ConsoleProject.Models
 {
-    [Required]
-    public string StageName { get; set; }
-    [Required]
-    public StageType StageType { get; set; }
-    public VideoInterviewStage VideoInterviewStage { get; set; }
-    public ICollection<Application> Applications { get; set; } = new HashSet<Application>();
+    // Stage represents a class that holds information about a specific stage in the application process.
+    public class Stage : BaseModel
+    {
+        // StageName represents the name of the stage and is required.
+        [Required]
+        public string StageName { get; set; }
+
+        // StageType represents the type of the stage (e.g., Applied, VideoInterview) and is required.
+        [Required]
+        public StageType StageType { get; set; }
+
+        // VideoInterviewStage represents the video interview stage for this specific stage (optional).
+        public VideoInterviewStage VideoInterviewStage { get; set; }
+
+        // Applications represents a collection of applications associated with this stage.
+        // The applications are initialized as an empty HashSet<Application>.
+        public ICollection<Application> Applications { get; set; } = new HashSet<Application>();
+    }
 }


### PR DESCRIPTION
Add Stage model to the application. The Stage class holds information about a specific stage in the application process, including the stage name, stage type, and an optional VideoInterviewStage for stages with video interviews. Additionally, the model includes a collection of applications associated with this stage, which is initialized as an empty HashSet<Application>. This model will be used to manage the different stages of the application process within the application.