### PR TITLE
Add ParagraphQuestion model

### DIFF
--- a/Project/ConsoleProject/Models/Questions/ParagraphQuestion.cs
+++ b/Project/ConsoleProject/Models/Questions/ParagraphQuestion.cs
@@ -1,7 +1,14 @@
-namespace ConsoleProject.Models;
-
-public class ParagraphQuestion 
+namespace ConsoleProject.Models
 {
-    //  public Guid QuestionId {get; set;}
-    // public Question Question {get; set;}
+    // ParagraphQuestion represents a class that holds information about a paragraph type question.
+    public class ParagraphQuestion
+    {
+        // QuestionId represents the unique identifier for the paragraph question.
+        public Guid QuestionId { get; set; }
+
+        // Question represents the actual question object associated with this paragraph question.
+        // It allows referencing the specific question to which this paragraph belongs.
+        // It is of type Question, assuming 'Question' is a class representing a general question.
+        public Question Question { get; set; }
+    }
 }


### PR DESCRIPTION
Add the ParagraphQuestion model to the application. The ParagraphQuestion class represents a paragraph type question, which is one of the possible question types in the application. It contains two properties: 'QuestionId' for uniquely identifying the paragraph question with a GUID, and 'Question' for referencing the general question object to which the paragraph belongs.